### PR TITLE
[Org Update] Update .NET to net8.0,net9.0,net10.0

### DIFF
--- a/Source/Directory.Packages.props
+++ b/Source/Directory.Packages.props
@@ -26,17 +26,17 @@
     <None Include="..\..\Readme.md" Pack="true" PackagePath="" Visible="false" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0" />
     <PackageVersion Include="Serilog" Version="4.3.0" />
-    <PackageVersion Include="Serilog.Extensions.Hosting" Version="8.0.0" />
+    <PackageVersion Include="Serilog.Extensions.Hosting" Version="9.0.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0" />
     <PackageVersion Include="Serilog" Version="4.3.0" />
     <PackageVersion Include="Serilog.Extensions.Hosting" Version="9.0.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />

--- a/Tools/Update-DotNet.ps1
+++ b/Tools/Update-DotNet.ps1
@@ -8,7 +8,7 @@ This script:
 - Removes Version attributes from PackageReference (enables central management)
 - Updates Directory.Packages.props with conditional ItemGroups per framework
 - Finds best compatible package versions for each framework
-- Supports prerelease packages for .NET 10+
+- Automatically detects if framework requires prerelease packages
 
 .PARAMETER TargetFrameworks
 List of target frameworks to support (e.g., "net8.0", "net9.0", "net10.0")
@@ -21,6 +21,7 @@ List of target frameworks to support (e.g., "net8.0", "net9.0", "net10.0")
 
 .NOTES
 Created for Zonit organization-wide .NET updates
+The script automatically detects preview .NET versions and uses prerelease packages only when necessary.
 #>
 
 param(
@@ -41,6 +42,58 @@ Write-Host "Target Frameworks: $($TargetFrameworks -join ', ')" -ForegroundColor
 Write-Host "========================================" -ForegroundColor Cyan
 
 # ============================================================================
+# FUNCTION: Detect if framework requires prerelease packages
+# =============================================================================
+function Test-RequiresPrerelease {
+    param(
+        [string]$TargetFramework,
+        [string]$SamplePackageId = "Microsoft.Extensions.Logging"
+    )
+    
+    try {
+        Write-Verbose "Testing if $TargetFramework requires prerelease packages..."
+        
+        # Extract major version from framework
+        if ($TargetFramework -notmatch 'net(\d+)\.') {
+            return $false
+        }
+        $targetMajor = [int]$matches[1]
+        
+        # Check if stable packages exist for this framework version
+        $url = "https://api.nuget.org/v3-flatcontainer/$($SamplePackageId.ToLower())/index.json"
+        $response = Invoke-RestMethod $url -TimeoutSec 10 -ErrorAction SilentlyContinue
+        
+        if (-not $response -or -not $response.versions) {
+            return $false
+        }
+        
+        # Check if there are any stable versions matching the target major version
+        $stableVersionsExist = $response.versions | Where-Object {
+            $_ -notmatch '-' -and $_ -match '^(\d+)\.'
+        } | ForEach-Object {
+            try {
+                $v = [version]($_ -replace '-.*', '')
+                $v.Major -ge $targetMajor
+            } catch {
+                $false
+            }
+        } | Where-Object { $_ -eq $true }
+        
+        # If no stable versions exist for this major version, we need prerelease
+        $needsPrerelease = @($stableVersionsExist).Count -eq 0
+        
+        if ($needsPrerelease) {
+            Write-Host "  [INFO] $TargetFramework appears to be prerelease - will allow preview packages" -ForegroundColor Yellow
+        }
+        
+        return $needsPrerelease
+    } catch {
+        Write-Verbose "Failed to detect prerelease requirement: $_"
+        return $false
+    }
+}
+
+# ============================================================================
 # FUNCTION: Get best package version for target framework
 # ============================================================================
 function Get-BestPackageVersion {
@@ -55,13 +108,12 @@ function Get-BestPackageVersion {
         $response = Invoke-RestMethod $url -TimeoutSec 15
         $versions = $response.versions
         
-        if ($TargetFramework -match 'net(\d+)') {
-            $targetMajor = [int]$matches[1]
-        } else {
-            Write-Warning "Cannot extract major version from $TargetFramework"
+        if (-not $versions -or $versions.Count -eq 0) {
+            Write-Warning "No versions found for ${PackageId}"
             return $null
         }
         
+        # Parse all versions
         $allVersions = $versions | ForEach-Object {
             try {
                 $v = [version]($_ -replace '-.*', '')
@@ -70,31 +122,49 @@ function Get-BestPackageVersion {
                     Version = $v
                     IsPrerelease = $_ -match '-'
                 }
-            } catch { $null }
+            } catch { 
+                Write-Verbose "Failed to parse version: $_"
+                $null 
+            }
         } | Where-Object { $_ -ne $null }
         
-        # Strategy (priority order):
-        # 1. Latest stable with exact major version
-        # 2. Latest stable with lower major version
-        # 3. Latest prerelease with exact major (if AllowPrerelease)
+        if ($allVersions.Count -eq 0) {
+            Write-Warning "No valid versions found for ${PackageId}"
+            return $null
+        }
         
-        $best = $allVersions | Where-Object { 
-            -not $_.IsPrerelease -and $_.Version.Major -eq $targetMajor 
-        } | Sort-Object -Property @{Expression={$_.Version}; Descending=$true} | Select-Object -First 1
+        # Improved strategy: Find latest compatible version regardless of version numbering scheme
+        # This works for ALL packages:
+        # - Microsoft packages with .NET-aligned versions (8.x, 9.x)
+        # - Microsoft packages with independent versions (CodeAnalysis 4.x, AspNetCore 2.x)
+        # - Third-party packages (Newtonsoft.Json 13.x, Serilog 3.x, etc.)
+        # Priority order:
+        # 1. Latest stable version (if not AllowPrerelease)
+        # 2. Latest version including prerelease (if AllowPrerelease)
+        
+        $best = $null
+        
+        if ($AllowPrerelease) {
+            # Allow any version (stable or prerelease)
+            $best = $allVersions | Sort-Object -Property @{Expression={$_.Version}; Descending=$true} | Select-Object -First 1
+        } else {
+            # Only stable versions
+            $best = $allVersions | Where-Object { -not $_.IsPrerelease } | Sort-Object -Property @{Expression={$_.Version}; Descending=$true} | Select-Object -First 1
+        }
         
         if (-not $best) {
-            $best = $allVersions | Where-Object { 
-                -not $_.IsPrerelease -and $_.Version.Major -lt $targetMajor 
-            } | Sort-Object -Property @{Expression={$_.Version}; Descending=$true} | Select-Object -First 1
+            Write-Warning "No suitable version found for ${PackageId} targeting ${TargetFramework}"
+            return $null
         }
         
-        if (-not $best -and $AllowPrerelease) {
-            $best = $allVersions | Where-Object { 
-                $_.Version.Major -eq $targetMajor 
-            } | Sort-Object -Property @{Expression={$_.Version}; Descending=$true} | Select-Object -First 1
+        # Ensure we return a full semantic version, never major-only
+        $resultVersion = $best.OriginalString
+        if ($resultVersion -match '^\d+$') {
+            Write-Warning "Rejecting major-only version '$resultVersion' for ${PackageId} - this is too broad"
+            return $null
         }
         
-        return $best.OriginalString
+        return $resultVersion
     } catch {
         Write-Warning "Error getting version for ${PackageId}: $_"
         return $null
@@ -136,9 +206,9 @@ foreach ($proj in $csprojs) {
         $pg.AppendChild($tfNode) | Out-Null
         
         $xml.Save($proj.FullName)
-        Write-Host "  ✓ $($proj.Name): Set to $targetFrameworksString" -ForegroundColor Green
+        Write-Host "  [OK] $($proj.Name): Set to $targetFrameworksString" -ForegroundColor Green
     } catch {
-        Write-Warning "  ✗ Failed to update $($proj.Name): $_"
+        Write-Warning "  [FAIL] Failed to update $($proj.Name): $_"
     }
 }
 
@@ -152,9 +222,9 @@ foreach ($proj in $csprojs) {
         $content = Get-Content $proj.FullName -Raw
         $content = $content -replace '(<PackageReference\s+Include="[^"]+")(\s+Version="[^"]+")', '$1'
         $content | Set-Content $proj.FullName -NoNewline
-        Write-Host "  ✓ $($proj.Name)" -ForegroundColor Gray
+        Write-Host "  [OK] $($proj.Name)" -ForegroundColor Gray
     } catch {
-        Write-Warning "  ✗ Failed to process $($proj.Name): $_"
+        Write-Warning "  [FAIL] Failed to process $($proj.Name): $_"
     }
 }
 
@@ -180,7 +250,7 @@ foreach ($proj in $csprojs) {
             }
         }
     } catch {
-        Write-Warning "  ✗ Failed to read packages from $($proj.Name): $_"
+        Write-Warning "  [FAIL] Failed to read packages from $($proj.Name): $_"
     }
 }
 
@@ -210,75 +280,274 @@ if (-not $propsFile) {
 # Track package version changes for report
 $packageChanges = @()
 
+# Initialize variables before try block to ensure they're always available for report
+$commonPackages = @{}
+$frameworkSpecificPackages = @{}
+
 try {
     [xml]$xml = Get-Content $propsFile.FullName
     
-    # Collect OLD versions before removing
+    # Remove TargetFrameworks from PropertyGroup if it exists (it should only be in .csproj files)
+    $propertyGroups = @($xml.Project.PropertyGroup)
+    foreach ($pg in $propertyGroups) {
+        if ($pg) {
+            @($pg.SelectNodes("TargetFramework")) | ForEach-Object { $pg.RemoveChild($_) | Out-Null }
+            @($pg.SelectNodes("TargetFrameworks")) | ForEach-Object { $pg.RemoveChild($_) | Out-Null }
+        }
+    }
+    
+    # Collect OLD versions and ALL child elements/attributes before removing
     $oldVersions = @{}
-    $existingItemGroups = @($xml.Project.ItemGroup | Where-Object { $_.Condition -match "TargetFramework" })
+    $packageAttributes = @{}
+    $packageChildElements = @{}
+    
+    # Get all ItemGroups (both conditional and unconditional)
+    $existingItemGroups = @($xml.Project.ItemGroup)
+    
     foreach ($ig in $existingItemGroups) {
-        $condition = $ig.Condition
-        if ($condition -match "'.*?' == '(net\d+\.\d+)'") {
-            $framework = $matches[1]
-            foreach ($pv in $ig.PackageVersion) {
-                if ($pv.Include -and $pv.Version) {
+        # Collect versions, attributes, and child elements from all ItemGroups
+        foreach ($pv in $ig.PackageVersion) {
+            if ($pv.Include -and $pv.Version) {
+                if ($ig.Condition -and $ig.Condition -match "'\`$\(TargetFramework\)' == '(net\d+\.\d+)'") {
+                    $framework = $matches[1]
                     $key = "$($pv.Include)|$framework"
-                    $oldVersions[$key] = $pv.Version
+                } else {
+                    $key = "$($pv.Include)|common"
+                }
+                $oldVersions[$key] = $pv.Version
+                
+                # Store all attributes except Include and Version
+                $attrs = @{}
+                foreach ($attr in $pv.Attributes) {
+                    if ($attr.Name -notin @('Include', 'Version')) {
+                        $attrs[$attr.Name] = $attr.Value
+                    }
+                }
+                if ($attrs.Count -gt 0) {
+                    $packageAttributes[$key] = $attrs
+                }
+                
+                # Store all child elements (like PrivateAssets, IncludeAssets, etc.)
+                $childElements = @()
+                foreach ($child in $pv.ChildNodes) {
+                    if ($child.NodeType -eq 'Element') {
+                        $childElements += [PSCustomObject]@{
+                            Name = $child.LocalName
+                            Value = $child.InnerText
+                        }
+                    }
+                }
+                if ($childElements.Count -gt 0) {
+                    $packageChildElements[$key] = $childElements
                 }
             }
         }
     }
     
-    # Remove existing conditional ItemGroups
+    # Remove ONLY conditional ItemGroups that match our target frameworks
+    # This allows us to recreate them with updated package versions
+    # PRESERVE unconditional ItemGroups (common packages without conditions)
     foreach ($ig in $existingItemGroups) {
-        $xml.Project.RemoveChild($ig) | Out-Null
+        $shouldRemove = $false
+        
+        if ($ig.PackageVersion -and $ig.Condition) {
+            # Check if this ItemGroup's condition matches any of our target frameworks
+            foreach ($tf in $TargetFrameworks) {
+                if ($ig.Condition -match [regex]::Escape($tf)) {
+                    $shouldRemove = $true
+                    break
+                }
+            }
+        }
+        
+        if ($shouldRemove) {
+            $xml.Project.RemoveChild($ig) | Out-Null
+        }
     }
     
+    # Collect package versions for each framework
+    $packageVersionsByFramework = @{}
+    $unresolvedPackages = @{}
+    
     foreach ($tf in $TargetFrameworks) {
-        $allowPrerelease = $tf -match 'net1[0-9]'  # Allow prerelease for net10+
+        # Auto-detect if framework requires prerelease packages
+        $allowPrereleaseForFramework = Test-RequiresPrerelease -TargetFramework $tf
         
-        Write-Host "  Processing $tf..." -ForegroundColor Cyan
+        $packageVersionsByFramework[$tf] = @{}
         
-        $itemGroup = $xml.CreateElement("ItemGroup")
-        $itemGroup.SetAttribute("Condition", "'`$(TargetFramework)' == '$tf'")
+        Write-Host "  Resolving versions for $tf..." -ForegroundColor Cyan
         
         foreach ($packageId in $packageList) {
-            $version = Get-BestPackageVersion -PackageId $packageId -TargetFramework $tf -AllowPrerelease $allowPrerelease
+            # Fetch best compatible version from NuGet based on framework requirements
+            $version = Get-BestPackageVersion -PackageId $packageId -TargetFramework $tf -AllowPrerelease $allowPrereleaseForFramework
             
             if ($version) {
+                $packageVersionsByFramework[$tf][$packageId] = $version
+            } else {
+                # Track unresolved packages
+                if (-not $unresolvedPackages.ContainsKey($packageId)) {
+                    $unresolvedPackages[$packageId] = @()
+                }
+                $unresolvedPackages[$packageId] += $tf
+                
+                # Try to preserve old version if it exists
+                $oldKey = "$packageId|$tf"
+                $oldCommonKey = "$packageId|common"
+                
+                if ($oldVersions.ContainsKey($oldKey)) {
+                    $preservedVersion = $oldVersions[$oldKey]
+                    $packageVersionsByFramework[$tf][$packageId] = $preservedVersion
+                    Write-Host "    [WARN] $packageId`: Could not resolve new version, preserving old version $preservedVersion for $tf" -ForegroundColor Yellow
+                } elseif ($oldVersions.ContainsKey($oldCommonKey)) {
+                    $preservedVersion = $oldVersions[$oldCommonKey]
+                    $packageVersionsByFramework[$tf][$packageId] = $preservedVersion
+                    Write-Host "    [WARN] $packageId`: Could not resolve new version, preserving old version $preservedVersion for $tf" -ForegroundColor Yellow
+                } else {
+                    Write-Warning "    [ERROR] $packageId`: Could not resolve version and no old version to preserve for $tf"
+                }
+            }
+            Start-Sleep -Milliseconds 100
+        }
+    }
+    
+    # Warn about unresolved packages
+    if ($unresolvedPackages.Count -gt 0) {
+        Write-Host "`n  [WARN] Warning: Some packages could not be resolved from NuGet:" -ForegroundColor Yellow
+        foreach ($pkg in $unresolvedPackages.Keys) {
+            $frameworks = $unresolvedPackages[$pkg] -join ', '
+            Write-Host "    - $pkg (for: $frameworks)" -ForegroundColor Yellow
+        }
+    }
+    
+    # Determine which packages can use a common version vs framework-specific
+    # NOTE: We ALWAYS create conditional ItemGroups for target frameworks
+    # even if all packages currently have the same version
+    $commonPackages = @{}
+    $frameworkSpecificPackages = @{}
+    
+    foreach ($packageId in $packageList) {
+        $versions = @()
+        foreach ($tf in $TargetFrameworks) {
+            if ($packageVersionsByFramework[$tf].ContainsKey($packageId)) {
+                $versions += $packageVersionsByFramework[$tf][$packageId]
+            }
+        }
+        
+        $uniqueVersions = $versions | Select-Object -Unique
+        
+        if ($uniqueVersions.Count -eq 1 -and $uniqueVersions[0]) {
+            # All frameworks use the same version - but we still add to framework-specific
+            # to maintain conditional ItemGroups per framework
+            $frameworkSpecificPackages[$packageId] = $true
+        } elseif ($uniqueVersions.Count -gt 1) {
+            # Different versions per framework
+            $frameworkSpecificPackages[$packageId] = $true
+        } elseif ($versions.Count -eq 0) {
+            # No version resolved for any framework - skip this package
+            Write-Warning "    Skipping $packageId - no version could be resolved for any framework"
+        }
+    }
+    
+    # Create conditional ItemGroups for ALL packages (per framework)
+    # This maintains the structure of having framework-specific package definitions
+    Write-Host "  Creating framework-specific package versions..." -ForegroundColor Yellow
+    
+    foreach ($tf in $TargetFrameworks) {
+        $itemGroup = $xml.CreateElement("ItemGroup")
+        $itemGroup.SetAttribute("Condition", "'`$(TargetFramework)' == '$tf'")
+        $hasPackages = $false
+        
+        foreach ($packageId in ($packageList | Sort-Object)) {
+            if ($packageVersionsByFramework[$tf].ContainsKey($packageId)) {
+                $version = $packageVersionsByFramework[$tf][$packageId]
+                
+                # Skip if version is invalid (null, "0", or major-only like "8")
+                if (-not $version -or $version -eq "0" -or $version -match '^\d+$') {
+                    Write-Warning "    [$tf] Skipping $packageId - invalid version: $version"
+                    continue
+                }
+                
                 $pkgVersion = $xml.CreateElement("PackageVersion")
                 $pkgVersion.SetAttribute("Include", $packageId)
                 $pkgVersion.SetAttribute("Version", $version)
-                $itemGroup.AppendChild($pkgVersion) | Out-Null
                 
-                # Track changes
-                $key = "$packageId|$tf"
-                $oldVersion = $oldVersions[$key]
-                if ($oldVersion -and $oldVersion -ne $version) {
+                # Restore additional attributes if they existed (check both framework-specific and common)
+                $attrKey = "$packageId|$tf"
+                $attrCommonKey = "$packageId|common"
+                if ($packageAttributes.ContainsKey($attrKey)) {
+                    foreach ($attrName in $packageAttributes[$attrKey].Keys) {
+                        $pkgVersion.SetAttribute($attrName, $packageAttributes[$attrKey][$attrName])
+                    }
+                } elseif ($packageAttributes.ContainsKey($attrCommonKey)) {
+                    foreach ($attrName in $packageAttributes[$attrCommonKey].Keys) {
+                        $pkgVersion.SetAttribute($attrName, $packageAttributes[$attrCommonKey][$attrName])
+                    }
+                }
+                
+                # Restore child elements (check both framework-specific and common)
+                $childKey = "$packageId|$tf"
+                $childCommonKey = "$packageId|common"
+                if ($packageChildElements.ContainsKey($childKey)) {
+                    foreach ($childElement in $packageChildElements[$childKey]) {
+                        $child = $xml.CreateElement($childElement.Name)
+                        $child.InnerText = $childElement.Value
+                        $pkgVersion.AppendChild($child) | Out-Null
+                    }
+                } elseif ($packageChildElements.ContainsKey($childCommonKey)) {
+                    foreach ($childElement in $packageChildElements[$childCommonKey]) {
+                        $child = $xml.CreateElement($childElement.Name)
+                        $child.InnerText = $childElement.Value
+                        $pkgVersion.AppendChild($child) | Out-Null
+                    }
+                }
+                
+                $itemGroup.AppendChild($pkgVersion) | Out-Null
+                $hasPackages = $true
+                
+                # Track changes - check both framework-specific key and common key
+                $oldVersion = $null
+                $oldKey = "$packageId|$tf"
+                
+                # First try to find old version in framework-specific configuration
+                if ($oldVersions.ContainsKey($oldKey)) {
+                    $oldVersion = $oldVersions[$oldKey]
+                }
+                
+                # If not found, check common configuration
+                if (-not $oldVersion) {
+                    $commonKey = "$packageId|common"
+                    if ($oldVersions.ContainsKey($commonKey)) {
+                        $oldVersion = $oldVersions[$commonKey]
+                    }
+                }
+                
+                # Track changes: both version updates AND new additions
+                if (-not $oldVersion -or $oldVersion -ne $version) {
                     $packageChanges += [PSCustomObject]@{
                         Package = $packageId
                         Framework = $tf
-                        OldVersion = $oldVersion
+                        OldVersion = if ($oldVersion) { $oldVersion } else { "(new)" }
                         NewVersion = $version
                     }
                 }
                 
                 $prereleaseLabel = if ($version -match '-') { " (prerelease)" } else { "" }
                 $changeLabel = if ($oldVersion -and $oldVersion -ne $version) { " (was $oldVersion)" } else { "" }
-                Write-Host "    - $packageId → $version$prereleaseLabel$changeLabel" -ForegroundColor Gray
-            } else {
-                Write-Warning "    ✗ Could not find version for $packageId"
+                $childLabel = if ($packageChildElements.ContainsKey($childKey) -or $packageChildElements.ContainsKey($childCommonKey)) { " [+children]" } else { "" }
+                $attrLabel = if ($packageAttributes.ContainsKey($attrKey) -or $packageAttributes.ContainsKey($attrCommonKey)) { " [+attrs]" } else { "" }
+                Write-Host "    [$tf] $packageId -> $version$prereleaseLabel$changeLabel$attrLabel$childLabel" -ForegroundColor DarkGray
             }
-            
-            # Rate limiting to respect NuGet API
-            Start-Sleep -Milliseconds 100
         }
         
-        $xml.Project.AppendChild($itemGroup) | Out-Null
+        if ($hasPackages) {
+            $xml.Project.AppendChild($itemGroup) | Out-Null
+        }
     }
-    
+
     $xml.Save($propsFile.FullName)
-    Write-Host "  ✓ Saved Directory.Packages.props" -ForegroundColor Green
+    Write-Host "  [OK] Saved Directory.Packages.props" -ForegroundColor Green
+    Write-Host "    Framework-specific package groups: $($TargetFrameworks.Count)" -ForegroundColor Gray
+    Write-Host "    Total packages configured: $($packageList.Count)" -ForegroundColor Gray
     
 } catch {
     Write-Error "Failed to update Directory.Packages.props: $_"
@@ -289,7 +558,7 @@ try {
 # SUMMARY
 # ============================================================================
 Write-Host "`n========================================" -ForegroundColor Green
-Write-Host "✓ Update Complete!" -ForegroundColor Green
+Write-Host "[OK] Update Complete!" -ForegroundColor Green
 Write-Host "========================================" -ForegroundColor Green
 
 # Generate detailed change summary
@@ -308,14 +577,14 @@ if ($packageChanges.Count -gt 0) {
             ($changes | Select-Object -ExpandProperty NewVersion -Unique).Count -eq 1) {
             $old = $changes[0].OldVersion
             $new = $changes[0].NewVersion
-            Write-Host "  $pkg`: $old → $new" -ForegroundColor White
-            $changeSummary += "$pkg`: $old → $new"
+            Write-Host "  $pkg : $old -> $new" -ForegroundColor White
+            $changeSummary += "$pkg : $old -> $new"
         } else {
             # Different versions per framework
-            Write-Host "  $pkg`:" -ForegroundColor White
+            Write-Host "  $pkg :" -ForegroundColor White
             foreach ($change in $changes) {
-                Write-Host "    [$($change.Framework)] $($change.OldVersion) → $($change.NewVersion)" -ForegroundColor Gray
-                $changeSummary += "$pkg [$($change.Framework)]: $($change.OldVersion) → $($change.NewVersion)"
+                Write-Host "    [$($change.Framework)] $($change.OldVersion) -> $($change.NewVersion)" -ForegroundColor Gray
+                $changeSummary += "$pkg [$($change.Framework)]: $($change.OldVersion) -> $($change.NewVersion)"
             }
         }
     }
@@ -324,6 +593,9 @@ if ($packageChanges.Count -gt 0) {
     $changeSummary += "No package version changes - this might be a new setup or no updates available"
 }
 
+# Join the summary into a single string for bash compatibility
+$changeSummaryText = $changeSummary -join "`n"
+
 # Generate report for PR automation
 $report = @{
     Timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
@@ -331,13 +603,14 @@ $report = @{
     ProjectsFound = $csprojs.Count
     PackagesFound = $packageList.Count
     PackageChanges = $packageChanges
-    ChangeSummary = $changeSummary
+    ChangeSummaryText = $changeSummaryText
     Summary = @{
         ProjectsUpdated = $csprojs.Count
         PackagesConfigured = $packageList.Count
         PackagesChanged = $packageChanges.Count
+        FrameworkSpecificGroups = $TargetFrameworks.Count
         FrameworksSet = $targetFrameworksString
-        DirectoryPackagesPropsUpdated = $propsFile -ne $null
+        DirectoryPackagesPropsUpdated = [bool]$propsFile
     }
 }
 

--- a/dotnet-update-report.json
+++ b/dotnet-update-report.json
@@ -1,49 +1,63 @@
 {
-  "Timestamp": "2025-11-15 19:15:17",
+  "PackagesFound": 6,
+  "ChangeSummaryText": "Microsoft.Extensions.DependencyInjection.Abstractions [net8.0]: 8.0.2 -> 10.0.0\nMicrosoft.Extensions.DependencyInjection.Abstractions [net9.0]: 9.0.11 -> 10.0.0\nMicrosoft.Extensions.Hosting [net8.0]: 8.0.1 -> 10.0.0\nMicrosoft.Extensions.Hosting [net9.0]: 9.0.11 -> 10.0.0\nMicrosoft.Extensions.Hosting.Abstractions [net8.0]: 8.0.1 -> 10.0.0\nMicrosoft.Extensions.Hosting.Abstractions [net9.0]: 9.0.11 -> 10.0.0\nSerilog.Extensions.Hosting : 8.0.0 -> 9.0.0",
   "TargetFrameworks": [
     "net8.0",
     "net9.0",
     "net10.0"
   ],
   "ProjectsFound": 3,
-  "Summary": {
-    "DirectoryPackagesPropsUpdated": true,
-    "ProjectsUpdated": 3,
-    "PackagesConfigured": 6,
-    "PackagesChanged": 4,
-    "FrameworksSet": "net8.0;net9.0;net10.0"
-  },
   "PackageChanges": [
     {
       "Package": "Microsoft.Extensions.DependencyInjection.Abstractions",
-      "Framework": "net9.0",
-      "OldVersion": "9.0.5",
-      "NewVersion": "9.0.11"
+      "Framework": "net8.0",
+      "OldVersion": "8.0.2",
+      "NewVersion": "10.0.0"
     },
     {
       "Package": "Microsoft.Extensions.Hosting",
-      "Framework": "net9.0",
-      "OldVersion": "9.0.5",
-      "NewVersion": "9.0.11"
+      "Framework": "net8.0",
+      "OldVersion": "8.0.1",
+      "NewVersion": "10.0.0"
+    },
+    {
+      "Package": "Microsoft.Extensions.Hosting.Abstractions",
+      "Framework": "net8.0",
+      "OldVersion": "8.0.1",
+      "NewVersion": "10.0.0"
+    },
+    {
+      "Package": "Serilog.Extensions.Hosting",
+      "Framework": "net8.0",
+      "OldVersion": "8.0.0",
+      "NewVersion": "9.0.0"
     },
     {
       "Package": "Microsoft.Extensions.DependencyInjection.Abstractions",
-      "Framework": "net10.0",
-      "OldVersion": "10.0.0-preview.4.25258.110",
+      "Framework": "net9.0",
+      "OldVersion": "9.0.11",
       "NewVersion": "10.0.0"
     },
     {
       "Package": "Microsoft.Extensions.Hosting",
-      "Framework": "net10.0",
-      "OldVersion": "10.0.0-preview.4.25258.110",
+      "Framework": "net9.0",
+      "OldVersion": "9.0.11",
+      "NewVersion": "10.0.0"
+    },
+    {
+      "Package": "Microsoft.Extensions.Hosting.Abstractions",
+      "Framework": "net9.0",
+      "OldVersion": "9.0.11",
       "NewVersion": "10.0.0"
     }
   ],
-  "ChangeSummary": [
-    "Microsoft.Extensions.DependencyInjection.Abstractions [net10.0]: 10.0.0-preview.4.25258.110 → 10.0.0",
-    "Microsoft.Extensions.DependencyInjection.Abstractions [net9.0]: 9.0.5 → 9.0.11",
-    "Microsoft.Extensions.Hosting [net10.0]: 10.0.0-preview.4.25258.110 → 10.0.0",
-    "Microsoft.Extensions.Hosting [net9.0]: 9.0.5 → 9.0.11"
-  ],
-  "PackagesFound": 6
+  "Summary": {
+    "FrameworkSpecificGroups": 3,
+    "PackagesChanged": 7,
+    "FrameworksSet": "net8.0;net9.0;net10.0",
+    "ProjectsUpdated": 3,
+    "PackagesConfigured": 6,
+    "DirectoryPackagesPropsUpdated": true
+  },
+  "Timestamp": "2025-11-16 16:46:41"
 }


### PR DESCRIPTION
### Organization-Wide .NET Update

This PR was created as part of an organization-wide .NET update.

**Target Frameworks:** `net8.0,net9.0,net10.0`

**Tracking Issue:** https://github.com/Zonit/.github/issues/18

---

#### What Changed:
- **Projects Updated:** 3
- **Packages Configured:** 6
- **Package Versions Changed:** 7
- **Common Packages:** COMMON_6
- **Framework-Specific Packages:** 0
- **Target Frameworks:** `net8.0;net9.0;net10.0`
- **Central Package Management:** Enabled


**The following NuGet packages were updated:**

```
Microsoft.Extensions.DependencyInjection.Abstractions [net8.0]: 8.0.2 -> 10.0.0
Microsoft.Extensions.DependencyInjection.Abstractions [net9.0]: 9.0.11 -> 10.0.0
Microsoft.Extensions.Hosting [net8.0]: 8.0.1 -> 10.0.0
Microsoft.Extensions.Hosting [net9.0]: 9.0.11 -> 10.0.0
Microsoft.Extensions.Hosting.Abstractions [net8.0]: 8.0.1 -> 10.0.0
Microsoft.Extensions.Hosting.Abstractions [net9.0]: 9.0.11 -> 10.0.0
Serilog.Extensions.Hosting : 8.0.0 -> 9.0.0
```

---

**Next Steps:**
1. Review changes
2. Run `dotnet restore`
3. Run `dotnet build`
4. Run tests
5. Merge when ready

**Part of:** Organization-wide .NET update
**Tracking:** https://github.com/Zonit/.github/issues/18
