### PR TITLE
[Org Update] Update .NET to net8.0,net9.0,net10.0

### DIFF
--- a/Source/Directory.Packages.props
+++ b/Source/Directory.Packages.props
@@ -30,7 +30,7 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
     <PackageVersion Include="Serilog" Version="4.3.0" />
-    <PackageVersion Include="Serilog.Extensions.Hosting" Version="8.0.0" />
+    <PackageVersion Include="Serilog.Extensions.Hosting" Version="9.0.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">

--- a/dotnet-update-report.json
+++ b/dotnet-update-report.json
@@ -1,49 +1,27 @@
 {
-  "Timestamp": "2025-11-15 19:15:17",
+  "Summary": {
+    "DirectoryPackagesPropsUpdated": true,
+    "FrameworkSpecificGroups": 3,
+    "PackagesChanged": 1,
+    "ProjectsUpdated": 3,
+    "FrameworksSet": "net8.0;net9.0;net10.0",
+    "PackagesConfigured": 6
+  },
+  "Timestamp": "2025-11-17 02:09:54",
+  "ProjectsFound": 3,
+  "ChangeSummaryText": "Serilog.Extensions.Hosting : 8.0.0 -> 9.0.0",
+  "PackagesFound": 6,
+  "PackageChanges": [
+    {
+      "Package": "Serilog.Extensions.Hosting",
+      "Framework": "net8.0",
+      "OldVersion": "8.0.0",
+      "NewVersion": "9.0.0"
+    }
+  ],
   "TargetFrameworks": [
     "net8.0",
     "net9.0",
     "net10.0"
-  ],
-  "ProjectsFound": 3,
-  "Summary": {
-    "DirectoryPackagesPropsUpdated": true,
-    "ProjectsUpdated": 3,
-    "PackagesConfigured": 6,
-    "PackagesChanged": 4,
-    "FrameworksSet": "net8.0;net9.0;net10.0"
-  },
-  "PackageChanges": [
-    {
-      "Package": "Microsoft.Extensions.DependencyInjection.Abstractions",
-      "Framework": "net9.0",
-      "OldVersion": "9.0.5",
-      "NewVersion": "9.0.11"
-    },
-    {
-      "Package": "Microsoft.Extensions.Hosting",
-      "Framework": "net9.0",
-      "OldVersion": "9.0.5",
-      "NewVersion": "9.0.11"
-    },
-    {
-      "Package": "Microsoft.Extensions.DependencyInjection.Abstractions",
-      "Framework": "net10.0",
-      "OldVersion": "10.0.0-preview.4.25258.110",
-      "NewVersion": "10.0.0"
-    },
-    {
-      "Package": "Microsoft.Extensions.Hosting",
-      "Framework": "net10.0",
-      "OldVersion": "10.0.0-preview.4.25258.110",
-      "NewVersion": "10.0.0"
-    }
-  ],
-  "ChangeSummary": [
-    "Microsoft.Extensions.DependencyInjection.Abstractions [net10.0]: 10.0.0-preview.4.25258.110 → 10.0.0",
-    "Microsoft.Extensions.DependencyInjection.Abstractions [net9.0]: 9.0.5 → 9.0.11",
-    "Microsoft.Extensions.Hosting [net10.0]: 10.0.0-preview.4.25258.110 → 10.0.0",
-    "Microsoft.Extensions.Hosting [net9.0]: 9.0.5 → 9.0.11"
-  ],
-  "PackagesFound": 6
+  ]
 }


### PR DESCRIPTION
### Organization-Wide .NET Update

This PR was created as part of an organization-wide .NET update.

**Target Frameworks:** `net8.0,net9.0,net10.0`

**Tracking Issue:** https://github.com/Zonit/.github/issues/19

---

#### What Changed:
- **Projects Updated:** 3
- **Packages Configured:** 6
- **Package Versions Changed:** 1
- **Common Packages:** COMMON_6
- **Framework-Specific Packages:** 0
- **Target Frameworks:** `net8.0;net9.0;net10.0`
- **Central Package Management:** Enabled


**The following NuGet packages were updated:**

```
Serilog.Extensions.Hosting : 8.0.0 -> 9.0.0
```

---

**Next Steps:**
1. Review changes
2. Run `dotnet restore`
3. Run `dotnet build`
4. Run tests
5. Merge when ready

**Part of:** Organization-wide .NET update
**Tracking:** https://github.com/Zonit/.github/issues/19
