### PR TITLE
[Org Update] Update .NET to net8.0,net9.0,net10.0

### DIFF
--- a/Source/Directory.Packages.props
+++ b/Source/Directory.Packages.props
@@ -25,28 +25,20 @@
   <ItemGroup>
     <None Include="..\..\Readme.md" Pack="true" PackagePath="" Visible="false" />
   </ItemGroup>
+  <ItemGroup />
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
-    <PackageVersion Include="Serilog" Version="4.3.0" />
-    <PackageVersion Include="Serilog.Extensions.Hosting" Version="8.0.0" />
-    <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.11" />
-    <PackageVersion Include="Serilog" Version="4.3.0" />
-    <PackageVersion Include="Serilog.Extensions.Hosting" Version="9.0.0" />
-    <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0" />
-    <PackageVersion Include="Serilog" Version="4.3.0" />
-    <PackageVersion Include="Serilog.Extensions.Hosting" Version="9.0.0" />
-    <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
   </ItemGroup>
 </Project>

--- a/Tools/Update-DotNet.ps1
+++ b/Tools/Update-DotNet.ps1
@@ -4,11 +4,17 @@ Updates .NET target frameworks and manages NuGet packages with Central Package M
 
 .DESCRIPTION
 This script:
-- Updates TargetFrameworks in all .csproj files
-- Removes Version attributes from PackageReference (enables central management)
-- Updates Directory.Packages.props with conditional ItemGroups per framework
-- Finds best compatible package versions for each framework
-- Supports prerelease packages for .NET 10+
+1. Scans all .csproj files and collects used packages
+2. Adds TargetFrameworks to .csproj files
+3. Removes TargetFramework/TargetFrameworks from Directory.Packages.props (should only be in .csproj)
+4. Creates package list in Directory.Packages.props
+5. Creates target framework groups based on parameters (e.g., net8.0, net9.0, net10.0)
+6. Places all found packages in framework-specific groups
+7. Fetches package versions from NuGet:
+   - For Microsoft packages: looks for minor version matching target framework (e.g., 8.x.x for net8.0)
+   - For other packages: gets latest compatible version
+8. Checks for duplicates: if package version is identical across all frameworks, moves it to common ItemGroup
+9. Preserves additional attributes (PrivateAssets, etc.) and child elements
 
 .PARAMETER TargetFrameworks
 List of target frameworks to support (e.g., "net8.0", "net9.0", "net10.0")
@@ -41,6 +47,58 @@ Write-Host "Target Frameworks: $($TargetFrameworks -join ', ')" -ForegroundColor
 Write-Host "========================================" -ForegroundColor Cyan
 
 # ============================================================================
+# FUNCTION: Detect if framework requires prerelease packages
+# =============================================================================
+function Test-RequiresPrerelease {
+    param(
+        [string]$TargetFramework,
+        [string]$SamplePackageId = "Microsoft.Extensions.Logging"
+    )
+    
+    try {
+        Write-Verbose "Testing if $TargetFramework requires prerelease packages..."
+        
+        # Extract major version from framework
+        if ($TargetFramework -notmatch 'net(\d+)\.') {
+            return $false
+        }
+        $targetMajor = [int]$matches[1]
+        
+        # Check if stable packages exist for this framework version
+        $url = "https://api.nuget.org/v3-flatcontainer/$($SamplePackageId.ToLower())/index.json"
+        $response = Invoke-RestMethod $url -TimeoutSec 10 -ErrorAction SilentlyContinue
+        
+        if (-not $response -or -not $response.versions) {
+            return $false
+        }
+        
+        # Check if there are any stable versions matching the target major version
+        $stableVersionsExist = $response.versions | Where-Object {
+            $_ -notmatch '-' -and $_ -match '^(\d+)\.'
+        } | ForEach-Object {
+            try {
+                $v = [version]($_ -replace '-.*', '')
+                $v.Major -ge $targetMajor
+            } catch {
+                $false
+            }
+        } | Where-Object { $_ -eq $true }
+        
+        # If no stable versions exist for this major version, we need prerelease
+        $needsPrerelease = @($stableVersionsExist).Count -eq 0
+        
+        if ($needsPrerelease) {
+            Write-Host "  [INFO] $TargetFramework appears to be prerelease - will allow preview packages" -ForegroundColor Yellow
+        }
+        
+        return $needsPrerelease
+    } catch {
+        Write-Verbose "Failed to detect prerelease requirement: $_"
+        return $false
+    }
+}
+
+# ============================================================================
 # FUNCTION: Get best package version for target framework
 # ============================================================================
 function Get-BestPackageVersion {
@@ -55,46 +113,104 @@ function Get-BestPackageVersion {
         $response = Invoke-RestMethod $url -TimeoutSec 15
         $versions = $response.versions
         
-        if ($TargetFramework -match 'net(\d+)') {
+        if (-not $versions -or $versions.Count -eq 0) {
+            Write-Warning "No versions found for ${PackageId}"
+            return $null
+        }
+        
+        # Extract target major version from framework
+        if ($TargetFramework -match 'net(\d+)\.') {
             $targetMajor = [int]$matches[1]
         } else {
             Write-Warning "Cannot extract major version from $TargetFramework"
             return $null
         }
         
+        # Parse all versions and validate they are FULL semantic versions
         $allVersions = $versions | ForEach-Object {
             try {
+                # CRITICAL: Reject major-only versions (e.g., "4" -> reject, "4.0.0" -> OK)
+                if ($_ -match '^\d+$') {
+                    Write-Verbose "Rejecting major-only version: $_"
+                    return $null
+                }
+                
                 $v = [version]($_ -replace '-.*', '')
                 [PSCustomObject]@{
                     OriginalString = $_
                     Version = $v
                     IsPrerelease = $_ -match '-'
                 }
-            } catch { $null }
+            } catch { 
+                Write-Verbose "Failed to parse version: $_"
+                $null 
+            }
         } | Where-Object { $_ -ne $null }
         
-        # Strategy (priority order):
-        # 1. Latest stable with exact major version
-        # 2. Latest stable with lower major version
-        # 3. Latest prerelease with exact major (if AllowPrerelease)
+        if ($allVersions.Count -eq 0) {
+            Write-Warning "No valid versions found for ${PackageId}"
+            return $null
+        }
         
-        $best = $allVersions | Where-Object { 
-            -not $_.IsPrerelease -and $_.Version.Major -eq $targetMajor 
-        } | Sort-Object -Property @{Expression={$_.Version}; Descending=$true} | Select-Object -First 1
+        # Strategy for Microsoft packages vs third-party:
+        # 1. For Microsoft.* packages that follow .NET versioning - try to match major version (e.g., 8.x.x for net8.0)
+        # 2. For packages that don't follow .NET versioning - get latest compatible
+        
+        $best = $null
+        
+        # Check if this is a Microsoft package that typically follows .NET versioning
+        $followsDotNetVersioning = $PackageId -match '^Microsoft\.(Extensions|AspNetCore|EntityFrameworkCore|JSInterop)\.'
+        
+        if ($followsDotNetVersioning) {
+            # Strategy: Try to find version with Major == targetMajor (e.g., 8.x.x for net8.0)
+            # First try: exact major version match (preferred)
+            if ($AllowPrerelease) {
+                $best = $allVersions | Where-Object { 
+                    $_.Version.Major -eq $targetMajor 
+                } | Sort-Object -Property @{Expression={$_.Version}; Descending=$true} | Select-Object -First 1
+            } else {
+                $best = $allVersions | Where-Object { 
+                    $_.Version.Major -eq $targetMajor -and -not $_.IsPrerelease 
+                } | Sort-Object -Property @{Expression={$_.Version}; Descending=$true} | Select-Object -First 1
+            }
+            
+            # Second try: if no exact match, find highest version where Major <= targetMajor
+            if (-not $best) {
+                if ($AllowPrerelease) {
+                    $best = $allVersions | Where-Object { 
+                        $_.Version.Major -le $targetMajor 
+                    } | Sort-Object -Property @{Expression={$_.Version}; Descending=$true} | Select-Object -First 1
+                } else {
+                    $best = $allVersions | Where-Object { 
+                        $_.Version.Major -le $targetMajor -and -not $_.IsPrerelease 
+                    } | Sort-Object -Property @{Expression={$_.Version}; Descending=$true} | Select-Object -First 1
+                }
+            }
+        }
+        
+        # If not a .NET-versioned package OR no version found with above strategy
+        # Fall back to getting the latest compatible version
+        if (-not $best) {
+            if ($AllowPrerelease) {
+                $best = $allVersions | Sort-Object -Property @{Expression={$_.Version}; Descending=$true} | Select-Object -First 1
+            } else {
+                $best = $allVersions | Where-Object { -not $_.IsPrerelease } | Sort-Object -Property @{Expression={$_.Version}; Descending=$true} | Select-Object -First 1
+            }
+        }
         
         if (-not $best) {
-            $best = $allVersions | Where-Object { 
-                -not $_.IsPrerelease -and $_.Version.Major -lt $targetMajor 
-            } | Sort-Object -Property @{Expression={$_.Version}; Descending=$true} | Select-Object -First 1
+            Write-Warning "No suitable version found for ${PackageId} targeting ${TargetFramework}"
+            return $null
         }
         
-        if (-not $best -and $AllowPrerelease) {
-            $best = $allVersions | Where-Object { 
-                $_.Version.Major -eq $targetMajor 
-            } | Sort-Object -Property @{Expression={$_.Version}; Descending=$true} | Select-Object -First 1
+        # CRITICAL: Double-check we're not returning major-only version
+        $resultVersion = $best.OriginalString
+        if ($resultVersion -match '^\d+$') {
+            Write-Warning "CRITICAL: Rejecting major-only version '$resultVersion' for ${PackageId} - this would break compilation"
+            return $null
         }
         
-        return $best.OriginalString
+        return $resultVersion
     } catch {
         Write-Warning "Error getting version for ${PackageId}: $_"
         return $null
@@ -104,7 +220,7 @@ function Get-BestPackageVersion {
 # ============================================================================
 # STEP 1: Update TargetFrameworks in .csproj
 # ============================================================================
-Write-Host "`n[1/4] Updating TargetFrameworks in .csproj files..." -ForegroundColor Yellow
+Write-Host "`n[1/5] Updating TargetFrameworks in .csproj files..." -ForegroundColor Yellow
 
 # Use singular or plural based on count
 $targetFrameworksString = $TargetFrameworks -join ';'
@@ -114,11 +230,24 @@ $csprojs = Get-ChildItem -Recurse -Filter "*.csproj" | Where-Object {
     $_.FullName -notmatch '\\obj\\' -and $_.FullName -notmatch '\\bin\\' 
 }
 
+if ($csprojs.Count -eq 0) {
+    Write-Error "No .csproj files found in the current directory or subdirectories"
+    exit 1
+}
+
 foreach ($proj in $csprojs) {
     try {
         [xml]$xml = Get-Content $proj.FullName
+        
+        # Ensure Project element exists
+        if (-not $xml.Project) {
+            Write-Warning "  [SKIP] $($proj.Name): Invalid project file (no <Project> element)"
+            continue
+        }
+        
         $propertyGroups = @($xml.Project.PropertyGroup)
         if ($propertyGroups.Count -eq 0) {
+            # Create PropertyGroup if it doesn't exist
             $pg = $xml.CreateElement("PropertyGroup")
             $xml.Project.AppendChild($pg) | Out-Null
             $propertyGroups = @($pg)
@@ -126,9 +255,14 @@ foreach ($proj in $csprojs) {
         
         $pg = $propertyGroups[0]
         
+        # Check if TargetFramework or TargetFrameworks exists
+        $tfNodes = @($pg.SelectNodes("TargetFramework"))
+        $tfsNodes = @($pg.SelectNodes("TargetFrameworks"))
+        $hasTargetFramework = ($tfNodes.Count -gt 0) -or ($tfsNodes.Count -gt 0)
+        
         # Remove both singular and plural variants
-        @($pg.SelectNodes("TargetFramework")) | ForEach-Object { $pg.RemoveChild($_) | Out-Null }
-        @($pg.SelectNodes("TargetFrameworks")) | ForEach-Object { $pg.RemoveChild($_) | Out-Null }
+        foreach ($node in $tfNodes) { $pg.RemoveChild($node) | Out-Null }
+        foreach ($node in $tfsNodes) { $pg.RemoveChild($node) | Out-Null }
         
         # Add correct element name
         $tfNode = $xml.CreateElement($elementName)
@@ -136,34 +270,25 @@ foreach ($proj in $csprojs) {
         $pg.AppendChild($tfNode) | Out-Null
         
         $xml.Save($proj.FullName)
-        Write-Host "  ✓ $($proj.Name): Set to $targetFrameworksString" -ForegroundColor Green
+        
+        if ($hasTargetFramework) {
+            Write-Host "  [OK] $($proj.Name): Updated to $targetFrameworksString" -ForegroundColor Green
+        } else {
+            Write-Host "  [OK] $($proj.Name): Added $targetFrameworksString" -ForegroundColor Cyan
+        }
     } catch {
-        Write-Warning "  ✗ Failed to update $($proj.Name): $_"
+        Write-Warning "  [FAIL] Failed to update $($proj.Name): $_"
     }
 }
 
 # ============================================================================
-# STEP 2: Remove Version from PackageReference
+# STEP 2: Collect all packages with their metadata
 # ============================================================================
-Write-Host "`n[2/4] Removing Version attributes from PackageReference..." -ForegroundColor Yellow
+Write-Host "`n[2/5] Collecting package references from all .csproj files..." -ForegroundColor Yellow
 
-foreach ($proj in $csprojs) {
-    try {
-        $content = Get-Content $proj.FullName -Raw
-        $content = $content -replace '(<PackageReference\s+Include="[^"]+")(\s+Version="[^"]+")', '$1'
-        $content | Set-Content $proj.FullName -NoNewline
-        Write-Host "  ✓ $($proj.Name)" -ForegroundColor Gray
-    } catch {
-        Write-Warning "  ✗ Failed to process $($proj.Name): $_"
-    }
-}
+# Structure: packageId -> @{ Attributes, ChildElements }
+$allPackagesMetadata = @{}
 
-# ============================================================================
-# STEP 3: Collect all packages
-# ============================================================================
-Write-Host "`n[3/4] Collecting package references..." -ForegroundColor Yellow
-
-$allPackages = @{}
 foreach ($proj in $csprojs) {
     try {
         [xml]$xml = Get-Content $proj.FullName
@@ -173,30 +298,150 @@ foreach ($proj in $csprojs) {
             if ($ig) {
                 $packageRefs = @($ig.PackageReference)
                 foreach ($pkg in $packageRefs) {
-                    if ($pkg -and $pkg.Include) { 
-                        $allPackages[$pkg.Include] = $true 
+                    if ($pkg -and $pkg.Include) {
+                        $packageId = $pkg.Include
+                        
+                        if (-not $allPackagesMetadata.ContainsKey($packageId)) {
+                            # Store attributes (except Include and Version)
+                            $attrs = @{
+                            }
+                            foreach ($attr in $pkg.Attributes) {
+                                if ($attr.Name -notin @('Include', 'Version')) {
+                                    $attrs[$attr.Name] = $attr.Value
+                                }
+                            }
+                            
+                            # Store child elements (like PrivateAssets, IncludeAssets, etc.)
+                            $childElements = @()
+                            foreach ($child in $pkg.ChildNodes) {
+                                if ($child.NodeType -eq 'Element') {
+                                    $childElements += [PSCustomObject]@{
+                                        Name = $child.LocalName
+                                        Value = $child.InnerText
+                                    }
+                                }
+                            }
+                            
+                            $allPackagesMetadata[$packageId] = @{
+                                Attributes = $attrs
+                                ChildElements = $childElements
+                            }
+                        }
                     }
                 }
             }
         }
     } catch {
-        Write-Warning "  ✗ Failed to read packages from $($proj.Name): $_"
+        Write-Warning "  [FAIL] Failed to read packages from $($proj.Name): $_"
     }
 }
 
-$packageList = $allPackages.Keys | Sort-Object
-Write-Host "  Found $($packageList.Count) unique packages" -ForegroundColor Cyan
+$packageList = $allPackagesMetadata.Keys | Sort-Object
+Write-Host "  Found $($packageList.Count) unique packages across all projects" -ForegroundColor Cyan
+
+foreach ($pkg in $packageList) {
+    $metadata = $allPackagesMetadata[$pkg]
+    $attrInfo = if ($metadata.Attributes.Count -gt 0) { " [attrs: $($metadata.Attributes.Keys -join ', ')]" } else { "" }
+    $childInfo = if ($metadata.ChildElements.Count -gt 0) { " [children: $($metadata.ChildElements.Name -join ', ')]" } else { "" }
+    Write-Host "    - $pkg$attrInfo$childInfo" -ForegroundColor DarkGray
+}
 
 # ============================================================================
-# STEP 4: Update Directory.Packages.props
+# STEP 3: Remove Version from PackageReference in .csproj
 # ============================================================================
-Write-Host "`n[4/4] Updating Directory.Packages.props..." -ForegroundColor Yellow
+Write-Host "`n[3/5] Removing Version attributes from PackageReference in .csproj files..." -ForegroundColor Yellow
 
-$propsFile = Get-ChildItem -Filter "Directory.Packages.props" -Recurse | Select-Object -First 1
+foreach ($proj in $csprojs) {
+    try {
+        $content = Get-Content $proj.FullName -Raw
+        $content = $content -replace '(<PackageReference\s+Include="[^"]+")(\s+Version="[^"]+")', '$1'
+        $content | Set-Content $proj.FullName -NoNewline
+        Write-Host "  [OK] $($proj.Name)" -ForegroundColor Gray
+    } catch {
+        Write-Warning "  [FAIL] Failed to process $($proj.Name): $_"
+    }
+}
+
+# ============================================================================
+# STEP 4: Resolve package versions for each framework
+# ============================================================================
+Write-Host "`n[4/5] Resolving package versions for each framework..." -ForegroundColor Yellow
+
+# Structure: framework -> packageId -> version
+$packageVersionsByFramework = @{
+}
+$unresolvedPackages = @{
+}
+
+foreach ($tf in $TargetFrameworks) {
+    # Auto-detect if framework requires prerelease packages
+    $allowPrereleaseForFramework = Test-RequiresPrerelease -TargetFramework $tf
+    
+    $packageVersionsByFramework[$tf] = @{
+    }
+    
+    Write-Host "  Resolving versions for $tf..." -ForegroundColor Cyan
+    
+    foreach ($packageId in $packageList) {
+        # Fetch best compatible version from NuGet based on framework requirements
+        $version = Get-BestPackageVersion -PackageId $packageId -TargetFramework $tf -AllowPrerelease $allowPrereleaseForFramework
+        
+        if ($version) {
+            $packageVersionsByFramework[$tf][$packageId] = $version
+            $prereleaseLabel = if ($version -match '-') { " (prerelease)" } else { "" }
+            Write-Host "    [$tf] $packageId -> $version$prereleaseLabel" -ForegroundColor DarkGray
+        } else {
+            # Track unresolved packages
+            if (-not $unresolvedPackages.ContainsKey($packageId)) {
+                $unresolvedPackages[$packageId] = @()
+            }
+            $unresolvedPackages[$packageId] += $tf
+            Write-Warning "    [$tf] $packageId -> UNRESOLVED"
+        }
+        
+        Start-Sleep -Milliseconds 100
+    }
+}
+
+# Warn about unresolved packages
+if ($unresolvedPackages.Count -gt 0) {
+    Write-Host "`n  [WARN] Warning: Some packages could not be resolved from NuGet:" -ForegroundColor Yellow
+    foreach ($pkg in $unresolvedPackages.Keys) {
+        $frameworks = $unresolvedPackages[$pkg] -join ', '
+        Write-Host "    - $pkg (for: $frameworks)" -ForegroundColor Yellow
+    }
+}
+
+# ============================================================================
+# STEP 5: Create/Update Directory.Packages.props
+# ============================================================================
+Write-Host "`n[5/5] Creating/Updating Directory.Packages.props..." -ForegroundColor Yellow
+
+# CRITICAL FIX: Look for Directory.Packages.props in Source/ directory (Zonit convention)
+$propsFile = $null
+$searchPaths = @("Source", ".")
+
+foreach ($searchPath in $searchPaths) {
+    if (Test-Path $searchPath) {
+        $found = Get-ChildItem -Path $searchPath -Filter "Directory.Packages.props" -ErrorAction SilentlyContinue | Select-Object -First 1
+        if ($found) {
+            $propsFile = $found
+            Write-Host "  Found existing Directory.Packages.props in: $searchPath" -ForegroundColor Cyan
+            break
+        }
+    }
+}
+
+$oldVersions = @{
+
+}
+
 if (-not $propsFile) {
-    $propsPath = "Directory.Packages.props"
+    # Create in Source/ directory if it exists, otherwise in root
+    $propsPath = if (Test-Path "Source") { "Source\Directory.Packages.props" } else { "Directory.Packages.props" }
+    
+    # CRITICAL FIX: No XML declaration - MSBuild doesn't need it
     @"
-<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
@@ -204,81 +449,203 @@ if (-not $propsFile) {
 </Project>
 "@ | Set-Content $propsPath
     $propsFile = Get-Item $propsPath
-    Write-Host "  Created new Directory.Packages.props" -ForegroundColor Green
-}
-
-# Track package version changes for report
-$packageChanges = @()
-
-try {
-    [xml]$xml = Get-Content $propsFile.FullName
-    
-    # Collect OLD versions before removing
-    $oldVersions = @{}
-    $existingItemGroups = @($xml.Project.ItemGroup | Where-Object { $_.Condition -match "TargetFramework" })
-    foreach ($ig in $existingItemGroups) {
-        $condition = $ig.Condition
-        if ($condition -match "'.*?' == '(net\d+\.\d+)'") {
-            $framework = $matches[1]
+    Write-Host "  Created new Directory.Packages.props at: $propsPath" -ForegroundColor Green
+} else {
+    # Collect old versions for change tracking
+    try {
+        [xml]$existingXml = Get-Content $propsFile.FullName
+        $existingItemGroups = @($existingXml.Project.ItemGroup)
+        
+        foreach ($ig in $existingItemGroups) {
             foreach ($pv in $ig.PackageVersion) {
                 if ($pv.Include -and $pv.Version) {
-                    $key = "$($pv.Include)|$framework"
+                    if ($ig.Condition -and $ig.Condition -match "'\`$\(TargetFramework\)' == '(net\d+\.\d+)'") {
+                        $framework = $matches[1]
+                        $key = "$($pv.Include)|$framework"
+                    } else {
+                        $key = "$($pv.Include)|common"
+                    }
                     $oldVersions[$key] = $pv.Version
                 }
             }
         }
+    } catch {
+        Write-Verbose "Could not read existing packages from Directory.Packages.props"
     }
+}
+
+try {
+    [xml]$xml = Get-Content $propsFile.FullName
     
-    # Remove existing conditional ItemGroups
-    foreach ($ig in $existingItemGroups) {
-        $xml.Project.RemoveChild($ig) | Out-Null
-    }
-    
-    foreach ($tf in $TargetFrameworks) {
-        $allowPrerelease = $tf -match 'net1[0-9]'  # Allow prerelease for net10+
-        
-        Write-Host "  Processing $tf..." -ForegroundColor Cyan
-        
-        $itemGroup = $xml.CreateElement("ItemGroup")
-        $itemGroup.SetAttribute("Condition", "'`$(TargetFramework)' == '$tf'")
-        
-        foreach ($packageId in $packageList) {
-            $version = Get-BestPackageVersion -PackageId $packageId -TargetFramework $tf -AllowPrerelease $allowPrerelease
-            
-            if ($version) {
-                $pkgVersion = $xml.CreateElement("PackageVersion")
-                $pkgVersion.SetAttribute("Include", $packageId)
-                $pkgVersion.SetAttribute("Version", $version)
-                $itemGroup.AppendChild($pkgVersion) | Out-Null
-                
-                # Track changes
-                $key = "$packageId|$tf"
-                $oldVersion = $oldVersions[$key]
-                if ($oldVersion -and $oldVersion -ne $version) {
-                    $packageChanges += [PSCustomObject]@{
-                        Package = $packageId
-                        Framework = $tf
-                        OldVersion = $oldVersion
-                        NewVersion = $version
-                    }
-                }
-                
-                $prereleaseLabel = if ($version -match '-') { " (prerelease)" } else { "" }
-                $changeLabel = if ($oldVersion -and $oldVersion -ne $version) { " (was $oldVersion)" } else { "" }
-                Write-Host "    - $packageId → $version$prereleaseLabel$changeLabel" -ForegroundColor Gray
-            } else {
-                Write-Warning "    ✗ Could not find version for $packageId"
+    # Remove TargetFramework/TargetFrameworks from PropertyGroup (should only be in .csproj)
+    Write-Host "  Removing TargetFramework/TargetFrameworks from Directory.Packages.props..." -ForegroundColor Cyan
+    $propertyGroups = @($xml.Project.PropertyGroup)
+    foreach ($pg in $propertyGroups) {
+        if ($pg) {
+            @($pg.SelectNodes("TargetFramework")) | ForEach-Object { 
+                $pg.RemoveChild($_) | Out-Null
+                Write-Host "    [OK] Removed TargetFramework" -ForegroundColor Gray
             }
-            
-            # Rate limiting to respect NuGet API
-            Start-Sleep -Milliseconds 100
+            @($pg.SelectNodes("TargetFrameworks")) | ForEach-Object { 
+                $pg.RemoveChild($_) | Out-Null
+                Write-Host "    [OK] Removed TargetFrameworks" -ForegroundColor Gray
+            }
+        }
+    }
+    
+    # Remove all existing ItemGroups with PackageVersion
+    Write-Host "  Clearing existing package definitions..." -ForegroundColor Cyan
+    $existingItemGroups = @($xml.Project.ItemGroup)
+    foreach ($ig in $existingItemGroups) {
+        if ($ig.PackageVersion) {
+            $xml.Project.RemoveChild($ig) | Out-Null
+        }
+    }
+    
+    # ====================================================================================
+    # KLUCZOWA LOGIKA: Sprawdzanie duplikatów
+    # ====================================================================================
+    Write-Host "  Analyzing package versions across frameworks..." -ForegroundColor Cyan
+    
+    $commonPackages = @{}           # Packages with same version across ALL frameworks
+    $frameworkSpecificPackages = @{} # Packages with different versions per framework
+    
+    foreach ($packageId in $packageList) {
+        $versions = @()
+        $allResolved = $true
+        
+        # Collect versions for this package across all frameworks
+        foreach ($tf in $TargetFrameworks) {
+            if ($packageVersionsByFramework[$tf].ContainsKey($packageId)) {
+                $versions += $packageVersionsByFramework[$tf][$packageId]
+            } else {
+                $allResolved = $false
+            }
         }
         
-        $xml.Project.AppendChild($itemGroup) | Out-Null
+        # Check if all frameworks have the same version
+        $uniqueVersions = $versions | Select-Object -Unique
+        
+        if ($allResolved -and $uniqueVersions.Count -eq 1 -and $uniqueVersions[0]) {
+            # ALL frameworks use the SAME version -> move to common ItemGroup
+            $commonPackages[$packageId] = $uniqueVersions[0]
+            Write-Host "    [COMMON] $packageId -> $($uniqueVersions[0]) (same across all frameworks)" -ForegroundColor Green
+        } elseif ($uniqueVersions.Count -gt 1) {
+            # Different versions per framework -> keep in framework-specific groups
+            $frameworkSpecificPackages[$packageId] = $true
+            Write-Host "    [SPECIFIC] $packageId (different versions per framework)" -ForegroundColor Yellow
+        } elseif (-not $allResolved) {
+            # Not resolved for all frameworks -> skip
+            Write-Warning "    [SKIP] $packageId - not resolved for all frameworks"
+        }
+    }
+    
+    Write-Host "`n  Package distribution:" -ForegroundColor Cyan
+    Write-Host "    Common packages: $($commonPackages.Count)" -ForegroundColor Green
+    Write-Host "    Framework-specific packages: $($frameworkSpecificPackages.Count)" -ForegroundColor Yellow
+    
+    # ====================================================================================
+    # Create COMMON ItemGroup (for packages with same version across all frameworks)
+    # ====================================================================================
+    if ($commonPackages.Count -gt 0) {
+        Write-Host "`n  Creating common ItemGroup..." -ForegroundColor Cyan
+        $commonItemGroup = $xml.CreateElement("ItemGroup")
+        
+        foreach ($packageId in ($commonPackages.Keys | Sort-Object)) {
+            $version = $commonPackages[$packageId]
+            
+            # CRITICAL: Skip if version is invalid (null, "0", or major-only like "4")
+            if (-not $version -or $version -eq "0" -or $version -match '^\d+$') {
+                Write-Warning "    [SKIP] $packageId - invalid version: $version (would break compilation)"
+                continue
+            }
+            
+            $pkgVersion = $xml.CreateElement("PackageVersion")
+            $pkgVersion.SetAttribute("Include", $packageId)
+            $pkgVersion.SetAttribute("Version", $version)
+            
+            # Restore metadata (attributes and child elements)
+            $metadata = $allPackagesMetadata[$packageId]
+            
+            # Restore attributes
+            foreach ($attrName in $metadata.Attributes.Keys) {
+                $pkgVersion.SetAttribute($attrName, $metadata.Attributes[$attrName])
+            }
+            
+            # Restore child elements
+            foreach ($childElement in $metadata.ChildElements) {
+                $child = $xml.CreateElement($childElement.Name)
+                $child.InnerText = $childElement.Value
+                $pkgVersion.AppendChild($child) | Out-Null
+            }
+            
+            $commonItemGroup.AppendChild($pkgVersion) | Out-Null
+            
+            $attrLabel = if ($metadata.Attributes.Count -gt 0) { " [+attrs]" } else { "" }
+            $childLabel = if ($metadata.ChildElements.Count -gt 0) { " [+children]" } else { "" }
+            Write-Host "    $packageId -> $version$attrLabel$childLabel" -ForegroundColor Gray
+        }
+        
+        $xml.Project.AppendChild($commonItemGroup) | Out-Null
+    }
+    
+    # ====================================================================================
+    # Create FRAMEWORK-SPECIFIC ItemGroups (for packages with different versions)
+    # ====================================================================================
+    if ($frameworkSpecificPackages.Count -gt 0) {
+        Write-Host "`n  Creating framework-specific ItemGroups..." -ForegroundColor Cyan
+        
+        foreach ($tf in $TargetFrameworks) {
+            $itemGroup = $xml.CreateElement("ItemGroup")
+            $itemGroup.SetAttribute("Condition", "'`$(TargetFramework)' == '$tf'")
+            $hasPackages = $false
+            
+            foreach ($packageId in ($frameworkSpecificPackages.Keys | Sort-Object)) {
+                if ($packageVersionsByFramework[$tf].ContainsKey($packageId)) {
+                    $version = $packageVersionsByFramework[$tf][$packageId]
+                    
+                    # CRITICAL: Skip if version is invalid (null, "0", or major-only like "4")
+                    if (-not $version -or $version -eq "0" -or $version -match '^\d+$') {
+                        Write-Warning "    [$tf] [SKIP] $packageId - invalid version: $version (would break compilation)"
+                        continue
+                    }
+                    
+                    $pkgVersion = $xml.CreateElement("PackageVersion")
+                    $pkgVersion.SetAttribute("Include", $packageId)
+                    $pkgVersion.SetAttribute("Version", $version)
+                    
+                    # Restore metadata (attributes and child elements)
+                    $metadata = $allPackagesMetadata[$packageId]
+                    
+                    # Restore attributes
+                    foreach ($attrName in $metadata.Attributes.Keys) {
+                        $pkgVersion.SetAttribute($attrName, $metadata.Attributes[$attrName])
+                    }
+                    
+                    # Restore child elements
+                    foreach ($childElement in $metadata.ChildElements) {
+                        $child = $xml.CreateElement($childElement.Name)
+                        $child.InnerText = $childElement.Value
+                        $pkgVersion.AppendChild($child) | Out-Null
+                    }
+                    
+                    $itemGroup.AppendChild($pkgVersion) | Out-Null
+                    $hasPackages = $true
+                    
+                    $attrLabel = if ($metadata.Attributes.Count -gt 0) { " [+attrs]" } else { "" }
+                    $childLabel = if ($metadata.ChildElements.Count -gt 0) { " [+children]" } else { "" }
+                    Write-Host "    [$tf] $packageId -> $version$attrLabel$childLabel" -ForegroundColor DarkGray
+                }
+            }
+            
+            if ($hasPackages) {
+                $xml.Project.AppendChild($itemGroup) | Out-Null
+            }
+        }
     }
     
     $xml.Save($propsFile.FullName)
-    Write-Host "  ✓ Saved Directory.Packages.props" -ForegroundColor Green
+    Write-Host "`n  [OK] Saved Directory.Packages.props" -ForegroundColor Green
     
 } catch {
     Write-Error "Failed to update Directory.Packages.props: $_"
@@ -286,11 +653,50 @@ try {
 }
 
 # ============================================================================
-# SUMMARY
+# SUMMARY & CHANGE TRACKING
 # ============================================================================
 Write-Host "`n========================================" -ForegroundColor Green
-Write-Host "✓ Update Complete!" -ForegroundColor Green
+Write-Host "[OK] Update Complete!" -ForegroundColor Green
 Write-Host "========================================" -ForegroundColor Green
+
+# Track changes
+$packageChanges = @()
+
+foreach ($packageId in $packageList) {
+    # Check if in common or framework-specific
+    if ($commonPackages.ContainsKey($packageId)) {
+        $newVersion = $commonPackages[$packageId]
+        $oldKey = "$packageId|common"
+        $oldVersion = $oldVersions[$oldKey]
+        
+        if (-not $oldVersion -or $oldVersion -ne $newVersion) {
+            $packageChanges += [PSCustomObject]@{
+                Package = $packageId
+                Framework = "common"
+                OldVersion = if ($oldVersion) { $oldVersion } else { "(new)" }
+                NewVersion = $newVersion
+            }
+        }
+    } elseif ($frameworkSpecificPackages.ContainsKey($packageId)) {
+        foreach ($tf in $TargetFrameworks) {
+            if ($packageVersionsByFramework[$tf].ContainsKey($packageId)) {
+                $newVersion = $packageVersionsByFramework[$tf][$packageId]
+                $oldKey = "$packageId|$tf"
+                $oldCommonKey = "$packageId|common"
+                $oldVersion = if ($oldVersions.ContainsKey($oldKey)) { $oldVersions[$oldKey] } else { $oldVersions[$oldCommonKey] }
+                
+                if (-not $oldVersion -or $oldVersion -ne $newVersion) {
+                    $packageChanges += [PSCustomObject]@{
+                        Package = $packageId
+                        Framework = $tf
+                        OldVersion = if ($oldVersion) { $oldVersion } else { "(new)" }
+                        NewVersion = $newVersion
+                    }
+                }
+            }
+        }
+    }
+}
 
 # Generate detailed change summary
 $changeSummary = @()
@@ -308,21 +714,24 @@ if ($packageChanges.Count -gt 0) {
             ($changes | Select-Object -ExpandProperty NewVersion -Unique).Count -eq 1) {
             $old = $changes[0].OldVersion
             $new = $changes[0].NewVersion
-            Write-Host "  $pkg`: $old → $new" -ForegroundColor White
-            $changeSummary += "$pkg`: $old → $new"
+            Write-Host "  $pkg : $old -> $new" -ForegroundColor White
+            $changeSummary += "$pkg : $old -> $new"
         } else {
             # Different versions per framework
-            Write-Host "  $pkg`:" -ForegroundColor White
+            Write-Host "  $pkg :" -ForegroundColor White
             foreach ($change in $changes) {
-                Write-Host "    [$($change.Framework)] $($change.OldVersion) → $($change.NewVersion)" -ForegroundColor Gray
-                $changeSummary += "$pkg [$($change.Framework)]: $($change.OldVersion) → $($change.NewVersion)"
+                Write-Host "    [$($change.Framework)] $($change.OldVersion) -> $($change.NewVersion)" -ForegroundColor Gray
+                $changeSummary += "$pkg [$($change.Framework)]: $($change.OldVersion) -> $($change.NewVersion)"
             }
         }
     }
 } else {
     Write-Host "`nNo package version changes detected" -ForegroundColor Yellow
-    $changeSummary += "No package version changes - this might be a new setup or no updates available"
+    $changeSummary += "No package version changes - packages may already be up to date"
 }
+
+# Join the summary into a single string for bash compatibility
+$changeSummaryText = $changeSummary -join "`n"
 
 # Generate report for PR automation
 $report = @{
@@ -331,13 +740,15 @@ $report = @{
     ProjectsFound = $csprojs.Count
     PackagesFound = $packageList.Count
     PackageChanges = $packageChanges
-    ChangeSummary = $changeSummary
+    ChangeSummaryText = $changeSummaryText
     Summary = @{
         ProjectsUpdated = $csprojs.Count
         PackagesConfigured = $packageList.Count
         PackagesChanged = $packageChanges.Count
+        CommonPackages = $commonPackages.Count
+        FrameworkSpecificPackages = $frameworkSpecificPackages.Count
         FrameworksSet = $targetFrameworksString
-        DirectoryPackagesPropsUpdated = $propsFile -ne $null
+        DirectoryPackagesPropsUpdated = [bool]$propsFile
     }
 }
 
@@ -348,7 +759,9 @@ Write-Host "`nReport saved to: $reportPath" -ForegroundColor Gray
 Write-Host "`nSummary:" -ForegroundColor Cyan
 Write-Host "  Projects updated: $($csprojs.Count)" -ForegroundColor White
 Write-Host "  Target frameworks: $targetFrameworksString" -ForegroundColor White
-Write-Host "  Packages configured: $($packageList.Count)" -ForegroundColor White
+Write-Host "  Total packages: $($packageList.Count)" -ForegroundColor White
+Write-Host "    - Common packages: $($commonPackages.Count)" -ForegroundColor Green
+Write-Host "    - Framework-specific packages: $($frameworkSpecificPackages.Count)" -ForegroundColor Yellow
 Write-Host "  Package versions changed: $($packageChanges.Count)" -ForegroundColor White
 
 Write-Host "`nNext steps:" -ForegroundColor Cyan

--- a/dotnet-update-report.json
+++ b/dotnet-update-report.json
@@ -1,49 +1,40 @@
 {
-  "Timestamp": "2025-11-15 19:15:17",
-  "TargetFrameworks": [
-    "net8.0",
-    "net9.0",
-    "net10.0"
-  ],
+  "Timestamp": "2025-11-17 05:24:00",
   "ProjectsFound": 3,
+  "PackageChanges": [
+    {
+      "Package": "Serilog",
+      "Framework": "common",
+      "OldVersion": "(new)",
+      "NewVersion": "4"
+    },
+    {
+      "Package": "Serilog.Extensions.Hosting",
+      "Framework": "common",
+      "OldVersion": "(new)",
+      "NewVersion": "9"
+    },
+    {
+      "Package": "Serilog.Sinks.Console",
+      "Framework": "common",
+      "OldVersion": "(new)",
+      "NewVersion": "6"
+    }
+  ],
+  "PackagesFound": 6,
+  "ChangeSummaryText": "Serilog : (new) -> 4\nSerilog.Extensions.Hosting : (new) -> 9\nSerilog.Sinks.Console : (new) -> 6",
   "Summary": {
     "DirectoryPackagesPropsUpdated": true,
     "ProjectsUpdated": 3,
     "PackagesConfigured": 6,
-    "PackagesChanged": 4,
-    "FrameworksSet": "net8.0;net9.0;net10.0"
+    "PackagesChanged": 3,
+    "FrameworksSet": "net8.0;net9.0;net10.0",
+    "FrameworkSpecificPackages": 3,
+    "CommonPackages": 3
   },
-  "PackageChanges": [
-    {
-      "Package": "Microsoft.Extensions.DependencyInjection.Abstractions",
-      "Framework": "net9.0",
-      "OldVersion": "9.0.5",
-      "NewVersion": "9.0.11"
-    },
-    {
-      "Package": "Microsoft.Extensions.Hosting",
-      "Framework": "net9.0",
-      "OldVersion": "9.0.5",
-      "NewVersion": "9.0.11"
-    },
-    {
-      "Package": "Microsoft.Extensions.DependencyInjection.Abstractions",
-      "Framework": "net10.0",
-      "OldVersion": "10.0.0-preview.4.25258.110",
-      "NewVersion": "10.0.0"
-    },
-    {
-      "Package": "Microsoft.Extensions.Hosting",
-      "Framework": "net10.0",
-      "OldVersion": "10.0.0-preview.4.25258.110",
-      "NewVersion": "10.0.0"
-    }
-  ],
-  "ChangeSummary": [
-    "Microsoft.Extensions.DependencyInjection.Abstractions [net10.0]: 10.0.0-preview.4.25258.110 → 10.0.0",
-    "Microsoft.Extensions.DependencyInjection.Abstractions [net9.0]: 9.0.5 → 9.0.11",
-    "Microsoft.Extensions.Hosting [net10.0]: 10.0.0-preview.4.25258.110 → 10.0.0",
-    "Microsoft.Extensions.Hosting [net9.0]: 9.0.5 → 9.0.11"
-  ],
-  "PackagesFound": 6
+  "TargetFrameworks": [
+    "net8.0",
+    "net9.0",
+    "net10.0"
+  ]
 }


### PR DESCRIPTION
### Organization-Wide .NET Update

This PR was created as part of an organization-wide .NET update.

**Target Frameworks:** `net8.0,net9.0,net10.0`

**Tracking Issue:** https://github.com/Zonit/.github/issues/23

---

#### What Changed:
- **Projects Updated:** 3
- **Packages Configured:** 6
- **Package Versions Changed:** 3
- **Common Packages:** COMMON_6
- **Framework-Specific Packages:** 3
- **Target Frameworks:** `net8.0;net9.0;net10.0`
- **Central Package Management:** Enabled


**The following NuGet packages were updated:**

```
Serilog : (new) -> 4
Serilog.Extensions.Hosting : (new) -> 9
Serilog.Sinks.Console : (new) -> 6
```

---

**Next Steps:**
1. Review changes
2. Run `dotnet restore`
3. Run `dotnet build`
4. Run tests
5. Merge when ready

**Part of:** Organization-wide .NET update
**Tracking:** https://github.com/Zonit/.github/issues/23
